### PR TITLE
github/build.yml: add build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on: [push]
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        go: [1.16.x]
+    name: '${{ matrix.platform }} | ${{ matrix.go }}'
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Build
+        run: |
+          make build/vidx2pidx
+          make OS=windows ARCH=amd64 build/vidx2pidx.exe
+          make clean
+          make OS=darwin  ARCH=amd64 build/vidx2pidx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+[![Build](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/build.yml/badge.svg)](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/build.yml/badge.svg)
 [![Tests](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/test.yml/badge.svg)](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/test.yml/badge.svg)
-[![GoDoc](https://godoc.org/github.com/open-cmsis-pack/vidx2pidx?status.svg)](https://godoc.org/github.com/open-cmsis-pack/vidx2pidx)
 [![Go Report Card](https://goreportcard.com/badge/github.com/open-cmsis-pack/vidx2pidx)](https://goreportcard.com/report/github.com/open-cmsis-pack/vidx2pidx)
+[![GoDoc](https://godoc.org/github.com/open-cmsis-pack/vidx2pidx?status.svg)](https://godoc.org/github.com/open-cmsis-pack/vidx2pidx)
 
 # vidx2pidx: Open-CMSIS-Pack Package Index Generator Tool
 


### PR DESCRIPTION
This ensures that vidx2pidx builds for Linux/MacOS/Windows