### PR TITLE
Force option

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -45,7 +45,12 @@ func NewCli() *cobra.Command {
 
 			ExitOnError(EnsureDir(CacheDir))
 			ExitOnError(Vidx.Init(vidxFileName))
-			ExitOnError(Pidx.Update(Vidx))
+
+			err := Pidx.Update(Vidx)
+			if err != nil {
+				Logger.Error(err.Error())
+			}
+
 			ExitOnError(WriteXML(flags.outputFileName, Pidx))
 		},
 	}

--- a/cli.go
+++ b/cli.go
@@ -8,9 +8,10 @@ import (
 )
 
 var flags struct {
-	outputFileName    string
-	validatePidxFiles bool
-	version           bool
+	outputFileName string
+	force          bool
+	cacheDir       string
+	version        bool
 }
 
 func printVersionAndLicense(file io.Writer) {
@@ -38,7 +39,11 @@ func NewCli() *cobra.Command {
 
 			Vidx := NewVidx()
 			Pidx := NewPidx()
+			Pidx.SetForce(flags.force)
 
+			CacheDir = flags.cacheDir
+
+			ExitOnError(EnsureDir(CacheDir))
 			ExitOnError(Vidx.Init(vidxFileName))
 			ExitOnError(Pidx.Update(Vidx))
 			ExitOnError(WriteXML(flags.outputFileName, Pidx))
@@ -46,7 +51,9 @@ func NewCli() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&flags.outputFileName, "output", "o", "index.pidx", "Save pidx to this file")
-	cmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Output the version number of vidx2pidx and exit.")
+	cmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Output the version number of vidx2pidx and exit")
+	cmd.Flags().BoolVarP(&flags.force, "force", "f", false, "Force the update, ignoring timestamps and digging package descriptor files")
+	cmd.Flags().StringVarP(&flags.cacheDir, "cachedir", "c", ".idxcache", "Directory where to download and store pdsc files when using -f/--force flag")
 
 	return cmd
 }

--- a/pdsc.go
+++ b/pdsc.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+)
+
+type PdscXML struct {
+	XMLName xml.Name `xml:"package"`
+	Vendor  string   `xml:"vendor"`
+	URL     string   `xml:"url"`
+	Name    string   `xml:"name"`
+
+	ReleasesTag struct {
+		XMLName  xml.Name     `xml:"releases"`
+		Releases []ReleaseTag `xml:"release"`
+	} `xml:"releases"`
+}
+
+type ReleaseTag struct {
+	XMLName xml.Name `xml:"release"`
+	Version string   `xml:"version,attr"`
+	Date    string   `xml:"Date,attr"`
+}
+
+func (p *PdscXML) MatchTag(pdscTag PdscTag) error {
+	diff := ""
+
+	if p.Vendor != pdscTag.Vendor {
+		diff += fmt.Sprintf(" Vendor('%s' != '%s')", p.Vendor, pdscTag.Vendor)
+	}
+	if p.URL != pdscTag.URL {
+		diff += fmt.Sprintf(" URL('%s' != '%s')", p.URL, pdscTag.URL)
+	}
+	if p.Name != pdscTag.Name {
+		diff += fmt.Sprintf(" Name('%s' != '%s')", p.Name, pdscTag.Name)
+	}
+	if p.LatestVersion() != pdscTag.Version {
+		diff += fmt.Sprintf(" Version('%s' != '%s')", p.LatestVersion(), pdscTag.Version)
+	}
+
+	if len(diff) > 0 {
+		message := fmt.Sprintf("Pdsc tag '%s%s' does not match the actual file:%s", pdscTag.URL, pdscTag.Name, diff)
+		return errors.New(message)
+	}
+
+	return nil
+}
+
+func (p *PdscXML) LatestVersion() string {
+	releases := p.ReleasesTag.Releases
+	if len(releases) > 0 {
+		return releases[0].Version
+	}
+	return ""
+}
+
+func (p *PdscXML) Tag() PdscTag {
+	return PdscTag{
+		Vendor:  p.Vendor,
+		URL:     p.URL,
+		Name:    p.Name,
+		Version: p.LatestVersion(),
+	}
+}

--- a/pdsc_test.go
+++ b/pdsc_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"testing"
+	"fmt"
+)
+
+func TestPdscXML(t *testing.T) {
+	t.Run("test match pdsc tag with equal file content", func(t *testing.T) {
+		pdscTag := PdscTag{
+			Vendor:  "TheVendor",
+			URL:     "http://the.url/",
+			Name:    "TheName",
+			Version: "0.0.1",
+		}
+
+		pdscXML := PdscXML{
+			Vendor:  "TheVendor",
+			URL:     "http://the.url/",
+			Name:    "TheName",
+		}
+		release := ReleaseTag{
+			Version: "0.0.1",
+		}
+		pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, release)
+
+		err := pdscXML.MatchTag(pdscTag)
+		if err != nil {
+			t.Errorf("MatchTag should not return error on matching tag: %s", err)
+		}
+	})
+
+	t.Run("test match pdsc tag with different file content", func(t *testing.T) {
+		pdscTag := PdscTag{
+			Vendor:  "TheVendor",
+			URL:     "http://the.url/",
+			Name:    "TheName",
+			Version: "0.0.1",
+		}
+
+		pdscXML := PdscXML{
+			Vendor:  "TheVendor2",
+			URL:     "http://the.url2/",
+			Name:    "TheName2",
+		}
+		release := ReleaseTag{
+			Version: "0.0.2",
+		}
+		pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, release)
+
+		err := pdscXML.MatchTag(pdscTag)
+		expected := fmt.Sprintf("Pdsc tag '%s%s' does not match the actual file:", pdscTag.URL, pdscTag.Name)
+		expected += fmt.Sprintf(" Vendor('%s' != '%s')", pdscXML.Vendor, pdscTag.Vendor)
+		expected += fmt.Sprintf(" URL('%s' != '%s')", pdscXML.URL, pdscTag.URL)
+		expected += fmt.Sprintf(" Name('%s' != '%s')", pdscXML.Name, pdscTag.Name)
+		expected += fmt.Sprintf(" Version('%s' != '%s')", pdscXML.LatestVersion(), pdscTag.Version)
+
+		AssertEqual(t, err.Error(), expected)
+	})
+
+	t.Run("test latest version", func(t *testing.T) {
+		var latest string
+		pdscXML := PdscXML{
+			Vendor:  "TheVendor",
+			URL:     "http://the.url/",
+			Name:    "TheName",
+		}
+
+		latest = pdscXML.LatestVersion()
+		AssertEqual(t, latest, "")
+
+		release1 := ReleaseTag{
+			Version: "0.0.1",
+		}
+		release2 := ReleaseTag{
+			Version: "0.0.2",
+		}
+		pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, release2)
+		pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, release1)
+
+		latest = pdscXML.LatestVersion()
+		AssertEqual(t, latest, "0.0.2")
+	})
+
+	t.Run("test pdscXML to pdscTag generation", func(t *testing.T) {
+		pdscXML := PdscXML{
+			Vendor:  "TheVendor",
+			URL:     "http://the.url/",
+			Name:    "TheName",
+		}
+		release := ReleaseTag{
+			Version: "0.0.1",
+		}
+		pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, release)
+
+		pdscTag := pdscXML.Tag()
+		err := pdscXML.MatchTag(pdscTag)
+		if err != nil {
+			t.Errorf("MatchTag should not return error on matching tag: %s", err)
+		}
+	})
+}

--- a/pdsc_test.go
+++ b/pdsc_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 )
 
 func TestPdscXML(t *testing.T) {
@@ -15,9 +15,9 @@ func TestPdscXML(t *testing.T) {
 		}
 
 		pdscXML := PdscXML{
-			Vendor:  "TheVendor",
-			URL:     "http://the.url/",
-			Name:    "TheName",
+			Vendor: "TheVendor",
+			URL:    "http://the.url/",
+			Name:   "TheName",
 		}
 		release := ReleaseTag{
 			Version: "0.0.1",
@@ -39,9 +39,9 @@ func TestPdscXML(t *testing.T) {
 		}
 
 		pdscXML := PdscXML{
-			Vendor:  "TheVendor2",
-			URL:     "http://the.url2/",
-			Name:    "TheName2",
+			Vendor: "TheVendor2",
+			URL:    "http://the.url2/",
+			Name:   "TheName2",
 		}
 		release := ReleaseTag{
 			Version: "0.0.2",
@@ -61,9 +61,9 @@ func TestPdscXML(t *testing.T) {
 	t.Run("test latest version", func(t *testing.T) {
 		var latest string
 		pdscXML := PdscXML{
-			Vendor:  "TheVendor",
-			URL:     "http://the.url/",
-			Name:    "TheName",
+			Vendor: "TheVendor",
+			URL:    "http://the.url/",
+			Name:   "TheName",
 		}
 
 		latest = pdscXML.LatestVersion()
@@ -84,9 +84,9 @@ func TestPdscXML(t *testing.T) {
 
 	t.Run("test pdscXML to pdscTag generation", func(t *testing.T) {
 		pdscXML := PdscXML{
-			Vendor:  "TheVendor",
-			URL:     "http://the.url/",
-			Name:    "TheName",
+			Vendor: "TheVendor",
+			URL:    "http://the.url/",
+			Name:   "TheName",
 		}
 		release := ReleaseTag{
 			Version: "0.0.1",

--- a/pidx.go
+++ b/pidx.go
@@ -16,14 +16,14 @@ type PidxXML struct {
 	Timestamp string   `xml:"timestamp"`
 
 	Pindex struct {
-		XMLName xml.Name `xml:"pindex"`
-		Pdscs   []Pdsc   `xml:"pdsc"`
+		XMLName xml.Name  `xml:"pindex"`
+		Pdscs   []PdscTag `xml:"pdsc"`
 	} `xml:"pindex"`
 
 	pdscList map[string]bool
 }
 
-type Pdsc struct {
+type PdscTag struct {
 	XMLName   xml.Name `xml:"pdsc"`
 	Vendor    string   `xml:"vendor,attr"`
 	URL       string   `xml:"url,attr"`
@@ -38,7 +38,7 @@ func NewPidx() *PidxXML {
 	return p
 }
 
-func (p *PidxXML) addPdsc(pdsc Pdsc) error {
+func (p *PidxXML) addPdsc(pdsc PdscTag) error {
 	if p.pdscList[pdsc.getURL()] {
 		message := fmt.Sprintf("Package %s/%s/%s already exists!", pdsc.Vendor, pdsc.Name, pdsc.Version)
 		return errors.New(message)
@@ -48,7 +48,7 @@ func (p *PidxXML) addPdsc(pdsc Pdsc) error {
 	return nil
 }
 
-func (p *PidxXML) ListPdsc() []Pdsc {
+func (p *PidxXML) ListPdsc() []PdscTag {
 	Logger.Debug("Listing available packages")
 	return p.Pindex.Pdscs
 }
@@ -105,6 +105,6 @@ func (p *PidxXML) Update(vidx *VidxXML) error {
 	return nil
 }
 
-func (p *Pdsc) getURL() string {
+func (p *PdscTag) getURL() string {
 	return p.URL + p.Vendor + "." + p.Name + ".pdsc"
 }

--- a/pidx_test.go
+++ b/pidx_test.go
@@ -130,7 +130,7 @@ func TestAddPdsc(t *testing.T) {
 
 		newPdscTag := pdscList[0]
 		if newPdscTag.Version != "0.0.2" {
-			  t.Error("AddPdsc on a mismatch should add the pdsc tag generated from the pdsc file")
+			t.Error("AddPdsc on a mismatch should add the pdsc tag generated from the pdsc file")
 		}
 	})
 
@@ -139,9 +139,6 @@ func TestAddPdsc(t *testing.T) {
 		monkey.Patch(ReadXML, func(string, interface{}) error {
 			return errors.New(errMessage)
 		})
-
-
-
 
 		pidx := NewPidx()
 
@@ -172,7 +169,7 @@ func TestAddPdsc(t *testing.T) {
 		}
 
 		if pdscTag != pdscList[0] {
-			  t.Error("AddPdsc added something different than the original pdsc tag")
+			t.Error("AddPdsc added something different than the original pdsc tag")
 		}
 
 		monkey.Unpatch(ReadXML)

--- a/pidx_test.go
+++ b/pidx_test.go
@@ -20,7 +20,7 @@ func HTTPServer(output string) *httptest.Server {
 func TestAddPdsc(t *testing.T) {
 	t.Run("test fail if adding two existing packages", func(t *testing.T) {
 		pidx := NewPidx()
-		pdsc := Pdsc{
+		pdsc := PdscTag{
 			Vendor:  "TheVendor",
 			URL:     "http://the.url/",
 			Name:    "TheName",
@@ -45,14 +45,14 @@ func TestAddPdsc(t *testing.T) {
 
 	t.Run("test adding two different packages", func(t *testing.T) {
 		pidx := NewPidx()
-		pdsc1 := Pdsc{
+		pdsc1 := PdscTag{
 			Vendor:  "TheVendor",
 			URL:     "http://the.url/",
 			Name:    "TheName",
 			Version: "0.0.1",
 		}
 
-		pdsc2 := Pdsc{
+		pdsc2 := PdscTag{
 			Vendor:  "TheVendor2",
 			URL:     "http://the.url/",
 			Name:    "TheName2",
@@ -144,7 +144,7 @@ func TestUpdate(t *testing.T) {
 			Vendor: "TheVendor",
 			URL:    pidxServer.URL + "/",
 		})
-		vidx.Pindex.Pdscs = append(vidx.Pindex.Pdscs, Pdsc{
+		vidx.Pindex.Pdscs = append(vidx.Pindex.Pdscs, PdscTag{
 			Vendor:  "TheVendor",
 			URL:     "http://vendor.com/",
 			Name:    "ThePack",
@@ -186,7 +186,7 @@ func ExamplePidxXML_Update() {
 		Vendor: "TheVendor",
 		URL:    pidxServer.URL + "/",
 	})
-	vidx.Pindex.Pdscs = append(vidx.Pindex.Pdscs, Pdsc{
+	vidx.Pindex.Pdscs = append(vidx.Pindex.Pdscs, PdscTag{
 		Vendor:  "TheOtherVendor",
 		URL:     "http://other-vendor.com/",
 		Name:    "ThePackage",

--- a/pidx_test.go
+++ b/pidx_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"bou.ke/monkey"
 )
 
 func HTTPServer(output string) *httptest.Server {
@@ -78,6 +81,101 @@ func TestAddPdsc(t *testing.T) {
 		if len(pdscList) != 2 || pdscList[1] != pdsc2 {
 			t.Error("AddPdsc should not fail to add a valid pdsc")
 		}
+	})
+
+	t.Run("test force validating pdsc tag against actual pdsc file", func(t *testing.T) {
+		xml := `<package>
+			  <vendor>TheVendor</vendor>
+			  <name>TheName</name>
+			  <url>http://vendor.com/</url>
+			  <timestamp></timestamp>
+			  <releases>
+			    <!-- The version is intentionally different, to show off a pdsc mismatch -->
+			    <release version="0.0.2" />
+			  </releases>
+			</package>`
+		pdscServer := HTTPServer(xml)
+
+		pidx := NewPidx()
+
+		// Force checking pdsc file
+		pidx.SetForce(true)
+
+		pdscTag := PdscTag{
+			Vendor:  "TheVendor",
+			URL:     pdscServer.URL + "/",
+			Name:    "TheName",
+			Version: "0.0.1",
+		}
+
+		err := pidx.addPdsc(pdscTag)
+		if err == nil {
+			t.Errorf("AddPdsc should return an error with the mismatchin version")
+		}
+
+		expected := fmt.Sprintf("Pdsc tag '%s%s' does not match the actual file:", pdscTag.URL, pdscTag.Name)
+		expected += fmt.Sprintf(" URL('%s' != '%s')", "http://vendor.com/", pdscTag.URL)
+		expected += fmt.Sprintf(" Version('%s' != '%s')", "0.0.2", pdscTag.Version)
+
+		AssertEqual(t, err.Error(), expected)
+
+		pdscList := pidx.ListPdsc()
+		if len(pdscList) == 0 {
+			t.Error("AddPdsc should still add the pdsc despite the mismatch")
+		}
+
+		if len(pdscList) != 1 {
+			t.Error("AddPdsc should still add just one pdsc on mismatch")
+		}
+
+		newPdscTag := pdscList[0]
+		if newPdscTag.Version != "0.0.2" {
+			  t.Error("AddPdsc on a mismatch should add the pdsc tag generated from the pdsc file")
+		}
+	})
+
+	t.Run("test force validating is ignored when pdsc is unreachable", func(t *testing.T) {
+		errMessage := "failed to read XML"
+		monkey.Patch(ReadXML, func(string, interface{}) error {
+			return errors.New(errMessage)
+		})
+
+
+
+
+		pidx := NewPidx()
+
+		// Force checking pdsc file
+		pidx.SetForce(true)
+
+		pdscTag := PdscTag{
+			Vendor:  "TheVendor",
+			URL:     "http://vendor.com/",
+			Name:    "TheName",
+			Version: "0.0.1",
+		}
+
+		err := pidx.addPdsc(pdscTag)
+		if err == nil {
+			t.Errorf("AddPdsc should return an error when force checking a pdsc file that's unreachable")
+		}
+
+		AssertEqual(t, err.Error(), errMessage)
+
+		pdscList := pidx.ListPdsc()
+		if len(pdscList) == 0 {
+			t.Error("AddPdsc should still add the pdsc despite an unreachable pdsc file")
+		}
+
+		if len(pdscList) != 1 {
+			t.Error("AddPdsc should still add just one pdsc on unreachable pdsc file")
+		}
+
+		if pdscTag != pdscList[0] {
+			  t.Error("AddPdsc added something different than the original pdsc tag")
+		}
+
+		monkey.Unpatch(ReadXML)
 	})
 }
 

--- a/test/cypress.vidx
+++ b/test/cypress.vidx
@@ -9,5 +9,6 @@
   </vindex>
   <pindex>
     <pdsc url="http://packs.download.atmel.com/" vendor="Atmel" name="SAM3A_DFP" version="1.0.50" />
+    <pdsc url="non-existing-path/" vendor="TheVendor" name="TePack" version="1.0.50" />
   </pindex>
 </index>

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -27,6 +28,8 @@ func ExitOnError(err error) {
 	}
 }
 
+var CacheDir string
+
 func ReadURL(url string) ([]byte, error) {
 	var empty []byte
 	resp, err := http.Get(url)
@@ -43,6 +46,14 @@ func ReadURL(url string) ([]byte, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return empty, err
+	}
+
+	if len(CacheDir) > 0 {
+		fileName := path.Join(CacheDir, path.Base(url))
+		err = ioutil.WriteFile(fileName, body, 0666)
+		if err != nil {
+			return body, err
+		}
 	}
 
 	return body, nil
@@ -93,5 +104,13 @@ func WriteXML(path string, targetStruct interface{}) error {
 		return err
 	}
 
+	return nil
+}
+
+func EnsureDir(dirName string) error {
+	err := os.MkdirAll(dirName, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
 	return nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -130,7 +130,7 @@ func TestReadURL(t *testing.T) {
 			t.Error("ReadURL should return error when not able to write to cache")
 		}
 
-		if ! os.IsNotExist(err) {
+		if !os.IsNotExist(err) {
 			t.Errorf("Error should be related to no existing directory, instead got %s", err)
 		}
 	})

--- a/vidx.go
+++ b/vidx.go
@@ -22,8 +22,8 @@ type VidxXML struct {
 	} `xml:"vindex"`
 
 	Pindex struct {
-		XMLName xml.Name `xml:"pindex"`
-		Pdscs   []Pdsc   `xml:"pdsc"`
+		XMLName xml.Name  `xml:"pindex"`
+		Pdscs   []PdscTag `xml:"pdsc"`
 	} `xml:"pindex"`
 }
 
@@ -46,7 +46,7 @@ func (v *VidxXML) ListPidx() []VendorPidx {
 	return v.Vindex.VendorPidxs
 }
 
-func (v *VidxXML) ListPdsc() []Pdsc {
+func (v *VidxXML) ListPdsc() []PdscTag {
 	return v.Pindex.Pdscs
 }
 


### PR DESCRIPTION
Passing `-f/--force` will force vidx2pidx to go inside pdsc files cross-checking Vendor, URL, Name and Version against the pdsc tags provided in pidx and vidx files.

Also, by default files are going to be saved in `.idxcache` folder, but that can be customized by using `-c/--cachedir` flag