### PR TITLE
releasing: automate releasing process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Generate changelog
+        run: |
+          previous_tag="$(git describe --tags HEAD^ --abbrev=0)"
+          sed "/^# ${previous_tag}/q" CHANGELOG.md | head -n -1 > RELEASE_NOTES
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --release-notes=RELEASE_NOTES
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Build assets
+        run: |
+          mkdir -p build/{linux,windows,darwin}
+          make OS=linux  ARCH=amd64 build/vidx2pidx     && mv build/vidx2pidx     build/linux/
+          make OS=darwin ARCH=amd64 build/vidx2pidx     && mv build/vidx2pidx     build/darwin/
+          make OS=window ARCH=amd64 build/vidx2pidx.exe && mv build/vidx2pidx.exe build/windows/
+      - name: Upload assets
+        uses: actions/upload-artifact@v2
+        with:
+          name: vidx2pidx
+          path: build/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.0.0
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Release](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/build.yml/badge.svg)](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/build.yml/badge.svg)
 [![Build](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/build.yml/badge.svg)](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/build.yml/badge.svg)
 [![Tests](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/test.yml/badge.svg)](https://github.com/open-cmsis-pack/vidx2pidx/actions/workflows/test.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/open-cmsis-pack/vidx2pidx)](https://goreportcard.com/report/github.com/open-cmsis-pack/vidx2pidx)

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ all:
 
 $(PROG): $(SOURCES)
 	@echo Building project
-	GOOS=$(OS) GOARCH=$(ARCH) go build -o $(PROG)
+	GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "-X main.Version=`git describe`" -o $(PROG)
 
 run: $(PROG)
 	@./$(PROG) $(ARGS) || true
@@ -45,7 +45,7 @@ format-check:
 	$(GOFORMATTER) -d . | tee format-check.out
 	test ! -s format-check.out
 
-.PHONY: test
+.PHONY: test release
 test:
 	TESTING=1 go test $(ARGS)
 
@@ -60,5 +60,8 @@ coverage-check:
 	tail -n +2 cover.out | grep -v -e " 1$$" | grep -v main.go | tee coverage-check.out
 	test ! -s coverage-check.out
 
+release: # test-all build/vidx2pidx build/vidx2pidx.exe
+	@./scripts/release
+	
 clean:
 	rm -rf build/*

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+echo "Preparing release of vidx2pidx"
+
+# Sanity check, no uncommited changes are allowed
+changed=$(git diff-index --name-only HEAD -- || true)
+if [ -n "$changed" ]
+then
+    echo "Uncommited changes found; cannot release like this:"
+    echo "$changed"
+    echo "Commit these changes first! Aborting"
+    exit 1
+fi
+
+# Display current release version and ask for the next
+current_version=`git describe`
+echo "Current version is at: $current_version"
+echo -n " Next release version: v"
+read next_release_version
+
+# Make sure version is going up
+IFS=. read curr_major curr_mid curr_minor <<< ${current_version//-*/}
+IFS=. read next_major next_mid next_minor <<< $next_release_version
+diff_major=$(($next_major - $curr_major))
+diff_mid=$(($next_mid - $curr_mid))
+diff_minor=$(($next_minor - $curr_minor))
+if [ $diff_major -lt 0 ] ||
+   [ $diff_major -eq 0 -a $diff_mid -lt 0 ] ||
+   [ $diff_major -eq 0 -a $diff_mid -eq 0 -a $diff_minor -le 0 ]
+then
+	echo "Versions should always go up: (next) $next_release_version <= $current_version (current)"
+	echo "For more info, visit: https://semver.org/"
+	exit -1
+fi
+
+# Prepend a "v" before version number
+next_release_version=v${next_release_version}
+
+# Make sure release version hasn't been used before
+if git rev-parse --verify --quiet $next_release_version >/dev/null -o
+   grep -q "^# $next_release_version" CHANGELOG.md
+then
+    echo "Version $next_release_version has already been released. Aborting"
+    exit 1
+fi
+
+# Make sure to document changes
+if ! grep -q "^# $next_release_version" CHANGELOG.md
+then
+    echo "Document the changes in CHANGELOG.md"
+    editor CHANGELOG.md
+fi
+if ! grep -q "^# $next_release_version" CHANGELOG.md; then
+    echo "Version $next_release_version is not documented in CHANGELOG.md"
+    echo "Please do that before releasing. Aborting"
+    exit 1
+fi
+
+# Commit changes to CHANGELOG, bump up the version and push
+# tags so that github action can take care of the second
+# part of the release, see .github/workflows/release.yml
+echo git commit --message "New release: $next_release_version" CHANGELOG.md || true
+echo git tag -s -m "Vidx2pidx release $next_release_version" "$next_release_version"
+echo git push
+echo git push --tags

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const Version = "0.0.1"
+var Version string
 
 const License = `Copyright 2021 Linaro
 


### PR DESCRIPTION
This patch adds mainly two files to help automating vidx2pidx releasing process:

* scripts/release: It creates a new tag and open CHANGELOG.md so
  developers can write a brief statement of what has changed.
* .github/workflows/release.yml: it's the second stage of the release.
  When new tag is pushed to github, an CD job is triggered and
  a new Github release is added and binaries are uploaded accordingly

Signed-off-by: Charles Oliveira <charles.oliveira@linaro.org>