### PR TITLE
Updated golang-lint version and migrate configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           # must be specified without patch version
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,7 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,23 @@
+version: "2"
 run:
-  timeout: 10m
-
   # Run linters over integration tests
   build-tags:
     - integration
 
 linters:
-  disable-all: true # Disable defaults, then enable the ones we want
+  default: none
   enable:
-    # - deadcode
+    - bodyclose
     - errcheck
-    - gosimple
+    - gosec
     - govet
     - ineffassign
     - staticcheck
-    # - structcheck
-    - typecheck
     - unused
-    # - varcheck
-    - bodyclose
-    - stylecheck
-    - gosec
-    - goimports
-    - gci
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -96,7 +96,7 @@ func TestCli(t *testing.T) {
 </index>`
 		wd, _ := os.Getwd()
 		wd = filepath.ToSlash(wd)
-		expected = strings.Replace(expected, "XX", wd, -1)
+		expected = strings.ReplaceAll(expected, "XX", wd)
 		s := string(out)
 		sa, se, _ := strings.Cut(s, "timestamp") // cut out time, cannot compare
 		_, se, _ = strings.Cut(se, "timestamp")

--- a/cmd/pidx_test.go
+++ b/cmd/pidx_test.go
@@ -338,7 +338,7 @@ func TestPidxXML_Update(t *testing.T) {
  </pindex>
 </index>`
 		if runtime.GOOS == "windows" {
-			expected = strings.Replace(expected, "///uu", "//C:/uu", -1)
+			expected = strings.ReplaceAll(expected, "///uu", "//C:/uu")
 		}
 		s := string(out)
 		sa, se, _ := strings.Cut(s, "timestamp") // cut out time, cannot compare

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -118,7 +118,7 @@ func TestReadURL(t *testing.T) {
 		goodServer := httptest.NewServer(
 			http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintln(w, goodResponse)
+					fmt.Fprintln(w, string(goodResponse))
 				},
 			),
 		)
@@ -142,7 +142,7 @@ func TestReadURL(t *testing.T) {
 		goodServer := httptest.NewServer(
 			http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintln(w, goodResponse)
+					fmt.Fprintln(w, string(goodResponse))
 				},
 			),
 		)
@@ -157,7 +157,7 @@ func TestReadURL(t *testing.T) {
 		goodServer := httptest.NewServer(
 			http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintln(w, goodResponse)
+					fmt.Fprintln(w, string(goodResponse))
 				},
 			),
 		)


### PR DESCRIPTION
## Fixes
- Updated version of linter and migrated configuration to latest
- The new version of linter has megred many tools into one resulted in more checks than before. Hence there are few code updates required for. e.g _The linters `stylecheck`, `gosimple`, and `staticcheck `has been merged inside the `staticcheck`._
- Changes are listed under https://golangci-lint.run/product/migration-guide/

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
