### PR TITLE
Use pinned runner images for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,11 +101,11 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-24.04, windows-2022]
         include:
-          - platform: ubuntu-latest
+          - platform: ubuntu-24.04
             target: linux
-          - platform: windows-latest
+          - platform: windows-2022
             target: windows
     name: 'Test (${{ matrix.target }})'
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
## Changes
- Using pinned runner images as `windows-latest` shall be migrating to `Windows server 2025` instead of `windows-2022` 

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
