### PR TITLE
Workflow refinements

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,8 +17,6 @@ on:
       - 'go.sum'
       - 'makefile'
       - '!**/*.md'
-  push:
-    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The dependency-review-action requires both a base and head ref to compare dependency changes, which are only available in pull request-related events (pull_request, pull_request_target, or merge_group). On a push event, these refs are not present, so the action cannot run and shall fail with this error.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
